### PR TITLE
fixed avatar dropdown bug

### DIFF
--- a/src/components/common/Header.js
+++ b/src/components/common/Header.js
@@ -25,6 +25,11 @@ const Header = props => {
     props.history.push('/full-search');
   };
 
+  window.addEventListener('click', e => {
+    if (e.toElement.className !== 'profile-picture' ) 
+      setHamburgerMenu(false);
+  });
+
   return (
     <HeaderContainer>
       <div className='logo' onClick={() => {


### PR DESCRIPTION
## Avatar dropdown bug

**Description:** <!-- add description here -->
When the avatar is clicked, a dropdown menu shows up. There was a bug where it would only go away if you clicked on the avatar again. Now you should be able to click anywhere outside of the dropdown to make the dropdown disappear. 
  <!-- What was changed? -->
  <!-- Why does PR exist? -->
  <!-- How do your changes do what is intended? -->
  <!-- Will a screenshot be helpful? -->

### Tests

  <!-- Do we need tests? -->
