### PR TITLE
Removed prettier library. Download prettier as a VScode extension ins…

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,9 +5,9 @@
     "commonjs": true
   },
   "extends": [
-    "eslint:recommended", 
-    "plugin:react/recommended", 
-    "plugin:prettier/recommended"],
+    "eslint:recommended",
+    "plugin:react/recommended"
+  ],
   "parserOptions": {
     "ecmaFeatures": {
       "jsx": true
@@ -15,12 +15,12 @@
     "ecmaVersion": 2018,
     "sourceType": "module"
   },
-  "plugins": ["react", "prettier"],
+  "plugins": ["react"],
   "rules": {
-	"no-console": "warn",
-	"react/prop-types": 0,
-  "no-unused-vars": ["warn", { "vars": "all", "args": "after-used"}]
-},
+    "no-console": "warn",
+    "react/prop-types": 0,
+    "no-unused-vars": ["warn", { "vars": "all", "args": "after-used" }]
+  },
   "overrides": [
     {
       "files": ["**/*.test.js"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -14412,12 +14412,6 @@
 			"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
 			"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
 		},
-		"prettier": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
-			"integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
-			"dev": true
-		},
 		"prettier-linter-helpers": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
   "devDependencies": {
     "eslint-config-prettier": "^8.1.0",
     "eslint-plugin-prettier": "^3.3.1",
-    "eslint-plugin-react": "^7.22.0",
-    "prettier": "2.2.1"
+    "eslint-plugin-react": "^7.22.0"
   }
 }


### PR DESCRIPTION
…tead. Turn on 'format on save'

## PR TITLE

**Description:** 
Removed prettier library. Download prettier as a VScode extension instead. Turn on 'format on save'.